### PR TITLE
Execute terra scripts through stdin

### DIFF
--- a/syntax/terra.vim
+++ b/syntax/terra.vim
@@ -20,7 +20,7 @@ syn case match
 syn sync match terraSync grouphere NONE @\v^\s*%(function|terra|local|global|var)>@
 
 if s:terra_is_executable
-  let s:cmd = s:script_prg . shellescape(s:script_dir . '/terra_predefined.t')
+  let s:cmd = s:script_prg . ' - <' . shellescape(s:script_dir . '/terra_predefined.t')
   call execute(split(system(s:cmd), "\n"))
 else
 " Predefined Variables {
@@ -144,7 +144,7 @@ syn keyword terraNull           nil
 hi def link terraNull           Constant
 
 if s:terra_is_executable
-  let s:cmd = s:script_prg . shellescape(s:script_dir . '/terra_type.t')
+  let s:cmd = s:script_prg . ' - < ' . shellescape(s:script_dir . '/terra_type.t')
   call execute(split(system(s:cmd), "\n"))
 else
 " Builtin Types {


### PR DESCRIPTION
First of all, thanks for the terra vim plugin!

I'm using a workflow where I have `terra` installed within a container but then
have a local `terra` wrapper which simply does an exec of `terra` within a
container. That effectively means that `terra` can only see my project's source
files and not evetything from the host system.

In this PR I make the vim plugin to execute bundled terra scripts through stdin
instead.

